### PR TITLE
refactor: remove unused `StorageException`

### DIFF
--- a/src/Eventify.Infrastructure/Common/Storage/StorageException.cs
+++ b/src/Eventify.Infrastructure/Common/Storage/StorageException.cs
@@ -1,4 +1,0 @@
-namespace Eventify.Infrastructure.Common.Storage;
-
-internal sealed class StorageException(string message, Exception? innerException = null) 
-    : Exception(message, innerException);


### PR DESCRIPTION
The `StorageException.cs` was removed because it was not being used.